### PR TITLE
fix: update api endpoint link to new link

### DIFF
--- a/src/services/svglService/index.js
+++ b/src/services/svglService/index.js
@@ -1,5 +1,5 @@
 async function fetchSVGs(query) {
-    const response = await fetch(`https://svgl.app/api/svgs?search=${encodeURIComponent(query)}`);
+    const response = await fetch(`https://api.svgl.app?search=${encodeURIComponent(query)}`);
     if (!response.ok) {
         throw new Error('SVGL service is down');
     }

--- a/test/services/svglServive/svglService.test.js
+++ b/test/services/svglServive/svglService.test.js
@@ -13,7 +13,7 @@ describe('SVG Service', () => {
             const result = await fetchSVGs('test');
 
             expect(result).toEqual({ data: 'some SVG data' });
-            expect(fetch).toHaveBeenCalledWith('https://svgl.app/api/svgs?search=test');
+            expect(fetch).toHaveBeenCalledWith('https://api.svgl.app?search=test');
         });
 
         it('should throw an error when the service is down', async () => {


### PR DESCRIPTION
The api endpoint was changed in pheralb/svgl#392 from [https://svgl.app/api/svgs](https://svgl.app/api/svgs) to [https://api.svgl.app](https://api.svgl.app), breaking this extension.